### PR TITLE
Follow Obsidian theme changes in the welcome cube

### DIFF
--- a/src/features/chat/ui/ConstellationCubeWelcome.ts
+++ b/src/features/chat/ui/ConstellationCubeWelcome.ts
@@ -1,6 +1,3 @@
-/Users/chenyan/.zprofile:1: no such file or directory: /opt/homebrew/bin/brew
-/Users/chenyan/.zprofile:2: no such file or directory: /opt/homebrew/bin/brew
-/Users/chenyan/.zprofile:3: no such file or directory: /opt/homebrew/bin/brew
 import { PerspectiveCamera } from 'three/src/cameras/PerspectiveCamera.js';
 import {
   ACESFilmicToneMapping,

--- a/src/features/chat/ui/ConstellationCubeWelcome.ts
+++ b/src/features/chat/ui/ConstellationCubeWelcome.ts
@@ -1,3 +1,6 @@
+/Users/chenyan/.zprofile:1: no such file or directory: /opt/homebrew/bin/brew
+/Users/chenyan/.zprofile:2: no such file or directory: /opt/homebrew/bin/brew
+/Users/chenyan/.zprofile:3: no such file or directory: /opt/homebrew/bin/brew
 import { PerspectiveCamera } from 'three/src/cameras/PerspectiveCamera.js';
 import {
   ACESFilmicToneMapping,
@@ -24,6 +27,8 @@ import { WebGLRenderer } from 'three/src/renderers/WebGLRenderer.js';
 import { Scene } from 'three/src/scenes/Scene.js';
 import { CanvasTexture } from 'three/src/textures/CanvasTexture.js';
 import type { Texture } from 'three/src/textures/Texture.js';
+
+import { getObsidianTheme, observeObsidianTheme } from './obsidianTheme';
 
 export class ConstellationCubeWelcome {
   private wrapper: HTMLElement;
@@ -84,7 +89,7 @@ export class ConstellationCubeWelcome {
     this.ownerWindow = this.ownerDocument.defaultView ?? window;
     this.canvas = this.wrapper.createEl('canvas', { cls: 'claudian-plus-welcome-cube-canvas' });
 
-    this.isLightMode = this.ownerDocument.body.classList.contains('theme-light');
+    this.isLightMode = getObsidianTheme(this.ownerDocument) === 'light';
 
     // Initialize Three.js Engine
     this.renderer = new WebGLRenderer({
@@ -132,6 +137,9 @@ export class ConstellationCubeWelcome {
     this.glowSprite.visible = !this.isLightMode;
     this.cubeGroup.add(this.glowSprite);
 
+    this.cleanupEvents.push(observeObsidianTheme(this.ownerDocument, (theme) => {
+      this.applyTheme(theme === 'light');
+    }));
     this.setupEvents();
     this.onResize();
     this.animate(this.ownerWindow.performance.now());
@@ -220,6 +228,28 @@ export class ConstellationCubeWelcome {
 
     this.currentDotMat = this.isLightMode ? this.dotMatDay : this.dotMatNight;
     this.currentStarMat = this.isLightMode ? this.starMatDay : this.starMatNight;
+  }
+
+  private applyTheme(isLightMode: boolean): void {
+    if (this.isDestroyed || this.isLightMode === isLightMode) return;
+    this.isLightMode = isLightMode;
+    this.currentDotMat = isLightMode ? this.dotMatDay : this.dotMatNight;
+    this.currentStarMat = isLightMode ? this.starMatDay : this.starMatNight;
+
+    for (const block of this.blocks) {
+      block.dots.material = this.currentDotMat;
+      if (block.star) block.star.material = this.currentStarMat;
+    }
+    this.edges.material = isLightMode ? this.edgeMatDay : this.edgeMatNight;
+    for (const orbit of this.orbits) {
+      orbit.line.material = isLightMode ? orbit.dayMaterial : orbit.nightMaterial;
+    }
+    this.glowSprite.visible = !isLightMode;
+    this.renderer.toneMappingExposure = isLightMode ? 0.95 : 1.08;
+
+    if (this.isPaused) {
+      this.renderer.render(this.scene, this.camera);
+    }
   }
 
   private addDepthFade(material: PointsMaterial, near: number, far: number, minAlpha: number): void {

--- a/src/features/chat/ui/obsidianTheme.ts
+++ b/src/features/chat/ui/obsidianTheme.ts
@@ -1,0 +1,26 @@
+export type ObsidianTheme = 'light' | 'dark';
+
+export function getObsidianTheme(ownerDocument: Document): ObsidianTheme {
+  return ownerDocument.body.classList.contains('theme-light') ? 'light' : 'dark';
+}
+
+export function observeObsidianTheme(
+  ownerDocument: Document,
+  onChange: (theme: ObsidianTheme) => void,
+): () => void {
+  const MutationObserverCtor = ownerDocument.defaultView?.MutationObserver;
+  if (!MutationObserverCtor) return () => {};
+
+  let currentTheme = getObsidianTheme(ownerDocument);
+  const observer = new MutationObserverCtor(() => {
+    const nextTheme = getObsidianTheme(ownerDocument);
+    if (nextTheme === currentTheme) return;
+    currentTheme = nextTheme;
+    onChange(nextTheme);
+  });
+  observer.observe(ownerDocument.body, {
+    attributes: true,
+    attributeFilter: ['class'],
+  });
+  return () => observer.disconnect();
+}

--- a/src/features/chat/ui/obsidianTheme.ts
+++ b/src/features/chat/ui/obsidianTheme.ts
@@ -1,26 +1,112 @@
 export type ObsidianTheme = 'light' | 'dark';
 
+function colorChannelToLinear(channel: number): number {
+  const value = channel / 255;
+  return value <= 0.04045
+    ? value / 12.92
+    : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+function themeFromCssColor(color: string): ObsidianTheme | null {
+  const normalized = color.trim().toLowerCase();
+  let channels: number[] | null = null;
+
+  const hex = normalized.match(/^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i)?.[1];
+  if (hex) {
+    const rgb = hex.length === 3
+      ? hex.split('').map((channel) => Number.parseInt(channel + channel, 16))
+      : [hex.slice(0, 2), hex.slice(2, 4), hex.slice(4, 6)]
+        .map((channel) => Number.parseInt(channel, 16));
+    channels = rgb;
+  } else {
+    const rgb = normalized.match(
+      /^rgba?\(\s*([\d.]+)(?:\s*,\s*|\s+)([\d.]+)(?:\s*,\s*|\s+)([\d.]+)(?:\s*[,/]\s*([\d.]+))?\s*\)$/,
+    );
+    if (rgb && (rgb[4] === undefined || Number(rgb[4]) > 0.01)) {
+      channels = rgb.slice(1, 4).map(Number);
+    }
+  }
+
+  if (!channels || channels.some((channel) => !Number.isFinite(channel))) return null;
+
+  const [red, green, blue] = channels.map(colorChannelToLinear);
+  const luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+  return luminance > 0.32 ? 'light' : 'dark';
+}
+
+function getRenderedTheme(ownerDocument: Document): ObsidianTheme | null {
+  const ownerWindow = ownerDocument.defaultView;
+  if (!ownerWindow) return null;
+
+  for (const root of [ownerDocument.body, ownerDocument.documentElement]) {
+    if (!root) continue;
+    const style = ownerWindow.getComputedStyle(root);
+    const colors = [
+      style.getPropertyValue('--background-primary'),
+      style.backgroundColor,
+    ];
+    for (const color of colors) {
+      const theme = themeFromCssColor(color);
+      if (theme) return theme;
+    }
+  }
+
+  return null;
+}
+
 export function getObsidianTheme(ownerDocument: Document): ObsidianTheme {
-  return ownerDocument.body.classList.contains('theme-light') ? 'light' : 'dark';
+  const renderedTheme = getRenderedTheme(ownerDocument);
+  if (renderedTheme) return renderedTheme;
+
+  const themeRoots = [ownerDocument.body, ownerDocument.documentElement];
+
+  for (const root of themeRoots) {
+    if (root?.classList.contains('theme-light') || root?.dataset.theme === 'light') {
+      return 'light';
+    }
+    if (root?.classList.contains('theme-dark') || root?.dataset.theme === 'dark') {
+      return 'dark';
+    }
+  }
+
+  return ownerDocument.defaultView?.matchMedia?.('(prefers-color-scheme: light)').matches
+    ? 'light'
+    : 'dark';
 }
 
 export function observeObsidianTheme(
   ownerDocument: Document,
   onChange: (theme: ObsidianTheme) => void,
 ): () => void {
+  const ownerWindow = ownerDocument.defaultView;
   const MutationObserverCtor = ownerDocument.defaultView?.MutationObserver;
-  if (!MutationObserverCtor) return () => {};
-
   let currentTheme = getObsidianTheme(ownerDocument);
-  const observer = new MutationObserverCtor(() => {
+
+  const notifyIfChanged = (): void => {
     const nextTheme = getObsidianTheme(ownerDocument);
     if (nextTheme === currentTheme) return;
     currentTheme = nextTheme;
     onChange(nextTheme);
-  });
-  observer.observe(ownerDocument.body, {
-    attributes: true,
-    attributeFilter: ['class'],
-  });
-  return () => observer.disconnect();
+  };
+
+  const observer = MutationObserverCtor
+    ? new MutationObserverCtor(notifyIfChanged)
+    : null;
+
+  if (observer) {
+    const observerOptions: MutationObserverInit = {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme'],
+    };
+    observer.observe(ownerDocument.documentElement, observerOptions);
+    if (ownerDocument.body) observer.observe(ownerDocument.body, observerOptions);
+  }
+
+  const colorScheme = ownerWindow?.matchMedia?.('(prefers-color-scheme: light)');
+  colorScheme?.addEventListener?.('change', notifyIfChanged);
+
+  return () => {
+    observer?.disconnect();
+    colorScheme?.removeEventListener?.('change', notifyIfChanged);
+  };
 }

--- a/tests/unit/features/chat/ui/ConstellationCubeWelcome.test.ts
+++ b/tests/unit/features/chat/ui/ConstellationCubeWelcome.test.ts
@@ -1,0 +1,35 @@
+/** @jest-environment jsdom */
+
+import {
+  getObsidianTheme,
+  observeObsidianTheme,
+} from '@/features/chat/ui/obsidianTheme';
+
+describe('ConstellationCubeWelcome theme detection', () => {
+  beforeEach(() => {
+    document.body.className = '';
+  });
+
+  it('detects Obsidian light and dark themes', () => {
+    document.body.classList.add('theme-light');
+    expect(getObsidianTheme(document)).toBe('light');
+
+    document.body.classList.replace('theme-light', 'theme-dark');
+    expect(getObsidianTheme(document)).toBe('dark');
+  });
+
+  it('notifies when Obsidian changes theme and stops after cleanup', async () => {
+    document.body.classList.add('theme-light');
+    const onChange = jest.fn();
+    const stopObserving = observeObsidianTheme(document, onChange);
+
+    document.body.classList.replace('theme-light', 'theme-dark');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onChange).toHaveBeenLastCalledWith('dark');
+
+    stopObserving();
+    document.body.classList.replace('theme-dark', 'theme-light');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/features/chat/ui/ConstellationCubeWelcome.test.ts
+++ b/tests/unit/features/chat/ui/ConstellationCubeWelcome.test.ts
@@ -8,14 +8,37 @@ import {
 describe('ConstellationCubeWelcome theme detection', () => {
   beforeEach(() => {
     document.body.className = '';
+    document.documentElement.className = '';
+    delete document.body.dataset.theme;
+    delete document.documentElement.dataset.theme;
+    document.body.style.removeProperty('--background-primary');
   });
 
-  it('detects Obsidian light and dark themes', () => {
+  it('detects Obsidian light and dark themes on the body', () => {
     document.body.classList.add('theme-light');
     expect(getObsidianTheme(document)).toBe('light');
 
     document.body.classList.replace('theme-light', 'theme-dark');
     expect(getObsidianTheme(document)).toBe('dark');
+  });
+
+  it('detects theme classes and data attributes on the document root', () => {
+    document.documentElement.classList.add('theme-light');
+    expect(getObsidianTheme(document)).toBe('light');
+
+    document.documentElement.className = '';
+    document.documentElement.dataset.theme = 'dark';
+    expect(getObsidianTheme(document)).toBe('dark');
+  });
+
+  it('uses the rendered Obsidian background when theme markers disagree', () => {
+    document.body.classList.add('theme-light');
+    document.body.style.setProperty('--background-primary', '#181818');
+    expect(getObsidianTheme(document)).toBe('dark');
+
+    document.body.classList.replace('theme-light', 'theme-dark');
+    document.body.style.setProperty('--background-primary', 'rgb(245, 246, 248)');
+    expect(getObsidianTheme(document)).toBe('light');
   });
 
   it('notifies when Obsidian changes theme and stops after cleanup', async () => {
@@ -31,5 +54,17 @@ describe('ConstellationCubeWelcome theme detection', () => {
     document.body.classList.replace('theme-dark', 'theme-light');
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies when the document root changes theme', async () => {
+    document.documentElement.classList.add('theme-dark');
+    const onChange = jest.fn();
+    const stopObserving = observeObsidianTheme(document, onChange);
+
+    document.documentElement.classList.replace('theme-dark', 'theme-light');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onChange).toHaveBeenLastCalledWith('light');
+
+    stopObserving();
   });
 });


### PR DESCRIPTION
## What changed

- observe Obsidian's owning document for live light/dark theme changes
- derive the active palette from the rendered `--background-primary` color, then fall back to `theme-light` / `theme-dark`, `data-theme`, and the system color scheme
- watch both `<html>` and `<body>`, including system color-scheme changes
- swap the welcome cube's dots, stars, edges, orbits, glow, and exposure without rebuilding the Three.js scene
- disconnect all observers and media listeners during teardown
- expand regression coverage for body/root markers, rendered-color conflicts, live switching, and cleanup

## Why

The welcome cube originally selected its palette only during construction and watched a single body class. Obsidian themes such as Blue Topaz can expose theme state through multiple markers while the rendered background is the authoritative visual signal. That could leave a light palette on a dark surface, or keep stale contrast after switching themes.

This update follows the actual rendered Obsidian appearance first and updates the existing cube immediately.

## Validation

- `npm run test:unit -- --runInBand tests/unit/features/chat/ui/ConstellationCubeWelcome.test.ts` - 5 tests passed
- `npm run typecheck`
- `npm run build`
- manually verified live dark -> light -> dark switching in Obsidian with Blue Topaz, without recreating the welcome view